### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v4.1.1
             - uses: actions/setup-node@v4.0.2
@@ -21,6 +23,9 @@ jobs:
     publish-npm:
         needs: build
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
         steps:
             - uses: actions/checkout@v4.1.1
             - uses: actions/setup-node@v4.0.2


### PR DESCRIPTION
Potential fix for [https://github.com/Wolfsin/aws-s3-archiver/security/code-scanning/4](https://github.com/Wolfsin/aws-s3-archiver/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for each job. For this workflow:
1. The `build` job only needs `contents: read` to run tests and install dependencies.
2. The `publish-npm` job requires `contents: read` and `packages: write` to publish the package to npm.

The `permissions` block can be added at the job level to ensure each job has the appropriate permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
