### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-test-by-pull-request.yml
+++ b/.github/workflows/npm-test-by-pull-request.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js TEST BY PULL REQUEST
+permissions:
+    contents: read
 
 on:
     pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Wolfsin/aws-s3-archiver/security/code-scanning/2](https://github.com/Wolfsin/aws-s3-archiver/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the workflow to `contents: read`, which is sufficient for the current steps in the workflow. This change ensures that the workflow does not inadvertently inherit broader permissions from the repository, reducing the risk of unauthorized actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
